### PR TITLE
fix `.length` on transient arrays

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1170,7 +1170,7 @@ string YulUtilFunctions::arrayLengthFunction(ArrayType const& _type)
 						length := tload(value)
 						<?byteArray>
 							length := <extractByteArrayLength>(length)
-7						</byteArray>
+						</byteArray>
 					</transient>
 					<?calldata>
 						length := len

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1166,6 +1166,12 @@ string YulUtilFunctions::arrayLengthFunction(ArrayType const& _type)
 							length := <extractByteArrayLength>(length)
 						</byteArray>
 					</storage>
+					<?transient>
+						length := tload(value)
+						<?byteArray>
+							length := <extractByteArrayLength>(length)
+7						</byteArray>
+					</transient>
 					<?calldata>
 						length := len
 					</calldata>


### PR DESCRIPTION
other issues:
- push on dynamic storage arrays is not supported
- still getting a compilation error on our codebase: `InternalCompilerError: Variable not found in transient storage.`